### PR TITLE
[Fix] 수정 요청 사항 전체 반영

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:17
+COPY build/libs/juksoon-0.0.1-SNAPSHOT.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/src/main/java/com/ureca/juksoon/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/ureca/juksoon/domain/feed/controller/FeedController.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,18 +33,18 @@ public class FeedController {
      * @param isAvailable
      * @param sortType
      */
-    @Operation(summary = "피드 상세 조회(Home)", description = "피드 전체 조회(Home) : sort는 사용X")
+    @Operation(summary = "피드 전체 조회(Home)", description = "피드 전체 조회(Home) : sort는 사용X")
     @GetMapping
     public CommonResponse<GetHomeInfoRes> getHomeInfo(
-        @ParameterObject Pageable pageable,
+        @ParameterObject @PageableDefault(size = 8) Pageable pageable,
         @Parameter(description = "검색어")
         @RequestParam(required = false) String keyword,
         @Parameter(description = "카테고리")
         @RequestParam(required = false) Category category,
         @Parameter(description = "신청 가능 여부")
-        @RequestParam(required = false, defaultValue = "true") boolean isAvailable,
+        @RequestParam(required = false, defaultValue = "false") boolean isAvailable,
         @Parameter(description = "피드 순서")
-        @RequestParam(required = false, defaultValue = "POPULAR") SortType sortType) {
+        @RequestParam(required = false, defaultValue = "RECENT") SortType sortType) {
         return CommonResponse.success(feedService.getHomeInfo(pageable, keyword, category, isAvailable, sortType));
     }
 
@@ -56,7 +57,7 @@ public class FeedController {
     public CommonResponse<GetMypageInfoRes> getMypageInfo(
         @Parameter(description = "사용자정보", required = true)
         @AuthenticationPrincipal CustomUserDetails userDetail,
-        @ParameterObject Pageable pageable,
+        @ParameterObject @PageableDefault(size = 8) Pageable pageable,
         @Parameter(description = "마지막 Feed Id")
         @RequestParam(required = false) Long lastFeedId) {
         return CommonResponse.success(feedService.getMypageInfo(userDetail.getUserId(), pageable, lastFeedId));

--- a/src/main/java/com/ureca/juksoon/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/ureca/juksoon/domain/feed/controller/FeedController.java
@@ -36,14 +36,14 @@ public class FeedController {
     @GetMapping
     public CommonResponse<GetHomeInfoRes> getHomeInfo(
         @ParameterObject Pageable pageable,
-        @Parameter(description = "검색어", required = false)
+        @Parameter(description = "검색어")
         @RequestParam(required = false) String keyword,
-        @Parameter(description = "카테고리", required = false)
+        @Parameter(description = "카테고리")
         @RequestParam(required = false) Category category,
-        @Parameter(description = "신청 가능 여부", required = true)
-        @RequestParam boolean isAvailable,
-        @Parameter(description = "피드 순서", required = true)
-        @RequestParam SortType sortType) {
+        @Parameter(description = "신청 가능 여부")
+        @RequestParam(required = false, defaultValue = "true") boolean isAvailable,
+        @Parameter(description = "피드 순서")
+        @RequestParam(required = false, defaultValue = "POPULAR") SortType sortType) {
         return CommonResponse.success(feedService.getHomeInfo(pageable, keyword, category, isAvailable, sortType));
     }
 

--- a/src/main/java/com/ureca/juksoon/domain/feed/dto/response/GetFeedRes.java
+++ b/src/main/java/com/ureca/juksoon/domain/feed/dto/response/GetFeedRes.java
@@ -34,7 +34,7 @@ public class GetFeedRes {
     @Schema(description = "상태", example = "OPEN")
     private Status status;
 
-    public GetFeedRes(Feed feed, UserRole role) {
+    public GetFeedRes(Feed feed) {
         this.feedId = feed.getId();
         this.title = feed.getTitle();
         this.maxUser = feed.getMaxUser();
@@ -43,10 +43,7 @@ public class GetFeedRes {
         this.expiredAt = feed.getExpiredAt();
         this.status = feed.getStatus();
         this.logoImageURL = feed.getStore().getLogoImageURL();
-
-        if(role != UserRole.ROLE_OWNER) { // 사장은 표기X
-            this.price = feed.getPrice();
-            this.storeName = feed.getStore().getName();
-        }
+        this.price = feed.getPrice();
+        this.storeName = feed.getStore().getName();
     }
 }

--- a/src/main/java/com/ureca/juksoon/domain/feed/dto/response/GetFeedRes.java
+++ b/src/main/java/com/ureca/juksoon/domain/feed/dto/response/GetFeedRes.java
@@ -20,6 +20,7 @@ public class GetFeedRes {
     private Integer price;
     @Schema(description = "가게 이름", example = "빽다방 선릉중앙점") // Optional
     private String storeName;
+    @JsonInclude(JsonInclude.Include.ALWAYS)
     @Schema(description = "가게 로고 Url", example = "링크")
     private String logoImageURL;
     @Schema(description = "최대 신청 인원", example = "20")

--- a/src/main/java/com/ureca/juksoon/domain/feed/dto/response/GetHomeInfoRes.java
+++ b/src/main/java/com/ureca/juksoon/domain/feed/dto/response/GetHomeInfoRes.java
@@ -9,6 +9,9 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class GetHomeInfoRes {
+    @Schema(description = "최대 Page 수", example = "최대 Page 수")
+    private Long maxPage;
+
     @Schema(description = "피드 List", example = "피드 List")
     private List<GetFeedRes> feedList;
 }

--- a/src/main/java/com/ureca/juksoon/domain/feed/dto/response/GetMypageInfoRes.java
+++ b/src/main/java/com/ureca/juksoon/domain/feed/dto/response/GetMypageInfoRes.java
@@ -20,6 +20,9 @@ public class GetMypageInfoRes {
     @Schema(description = "역할", example = "1")
     private UserRole role;
 
+    @Schema(description = "다음 페이지 존재 유무", example = "true")
+    private boolean hasNextPage;
+
     @Schema(description = "피드 List", example = "피드 List")
     private List<GetFeedRes> feedList;
 }

--- a/src/main/java/com/ureca/juksoon/domain/feed/entity/Feed.java
+++ b/src/main/java/com/ureca/juksoon/domain/feed/entity/Feed.java
@@ -14,7 +14,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Builder
-@Table(name = "feed")
+@Table(name = "feed", indexes = {
+    @Index(name = "idx_price_id", columnList = "price, id")
+})
 @NoArgsConstructor
 @AllArgsConstructor
 public class Feed extends BaseEntity {

--- a/src/main/java/com/ureca/juksoon/domain/feed/entity/SortType.java
+++ b/src/main/java/com/ureca/juksoon/domain/feed/entity/SortType.java
@@ -4,5 +4,5 @@ import lombok.Getter;
 
 @Getter
 public enum SortType {
-    POPULAR, RECENT, PRICE_ASC;
+    RECENT, PRICE_ASC;
 }

--- a/src/main/java/com/ureca/juksoon/domain/feed/repository/CustomFeedRepository.java
+++ b/src/main/java/com/ureca/juksoon/domain/feed/repository/CustomFeedRepository.java
@@ -10,7 +10,8 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface CustomFeedRepository {
-    List<Feed> findAllByFiltering(Pageable pageable, boolean isAvailable, SortType sortType, Category category, String keyword);
+    Long countAllByFiltering(boolean isAvailable, Category category, String keyword);
+    List<Feed> findPageByFiltering(Pageable pageable, boolean isAvailable, SortType sortType, Category category, String keyword);
     List<Feed> findAllByUserOrderByFeedIdDesc(Pageable pageable, User user, Long lastFeedId);
     List<Feed> findAllByStoreOrderByFeedIdDesc(Pageable pageable, Store store, Long lastFeedId);
 }

--- a/src/main/java/com/ureca/juksoon/domain/feed/repository/CustomFeedRepositoryImpl.java
+++ b/src/main/java/com/ureca/juksoon/domain/feed/repository/CustomFeedRepositoryImpl.java
@@ -24,10 +24,27 @@ public class CustomFeedRepositoryImpl implements CustomFeedRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     /**
+     * 필터링 시 전체 개수 count
+     */
+    @Override
+    public Long countAllByFiltering(boolean isAvailable, Category category, String keyword) {
+        return jpaQueryFactory
+            .select(feed.count())
+            .from(feed)
+            .leftJoin(feed.store, store)
+            .where(
+                isOpen(isAvailable),
+                categoryEq(category),
+                keywordContains(keyword)
+            )
+            .fetchOne();
+    }
+
+    /**
      * Feed 필터링 적용 전체 검색
      */
     @Override
-    public List<Feed> findAllByFiltering(Pageable pageable, boolean isAvailable, SortType sortType, Category category, String keyword) {
+    public List<Feed> findPageByFiltering(Pageable pageable, boolean isAvailable, SortType sortType, Category category, String keyword) {
         return jpaQueryFactory
             .selectFrom(feed)
             .leftJoin(feed.store, store)

--- a/src/main/java/com/ureca/juksoon/domain/feed/repository/CustomFeedRepositoryImpl.java
+++ b/src/main/java/com/ureca/juksoon/domain/feed/repository/CustomFeedRepositoryImpl.java
@@ -69,7 +69,7 @@ public class CustomFeedRepositoryImpl implements CustomFeedRepository {
             .where(
                 reservation.user.eq(user),
                 ltFeedId(lastFeedId))
-            .limit(pageable.getPageSize())
+            .limit(pageable.getPageSize() + 1) // 다음 페이지 유무 판단을 위해
             .fetch();
     }
 
@@ -81,7 +81,7 @@ public class CustomFeedRepositoryImpl implements CustomFeedRepository {
             .where(
                 feed.store.eq(store),
                 ltFeedId(lastFeedId))
-            .limit(pageable.getPageSize())
+            .limit(pageable.getPageSize() + 1) // 다음 페이지 유무 판단을 위해
             .fetch();
     }
 

--- a/src/main/java/com/ureca/juksoon/domain/feed/repository/CustomFeedRepositoryImpl.java
+++ b/src/main/java/com/ureca/juksoon/domain/feed/repository/CustomFeedRepositoryImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 import static com.ureca.juksoon.domain.feed.entity.QFeed.feed;
+import static com.ureca.juksoon.domain.feed.entity.SortType.PRICE_ASC;
 import static com.ureca.juksoon.domain.reservation.entity.QReservation.reservation;
 import static com.ureca.juksoon.domain.store.entity.QStore.store;
 
@@ -45,9 +46,10 @@ public class CustomFeedRepositoryImpl implements CustomFeedRepository {
      */
     @Override
     public List<Feed> findPageByFiltering(Pageable pageable, boolean isAvailable, SortType sortType, Category category, String keyword) {
-        return jpaQueryFactory
-            .selectFrom(feed)
-            .leftJoin(feed.store, store)
+        // 서브쿼리로 ID 먼저 추출
+        List<Long> feedIds = jpaQueryFactory
+            .select(feed.id)
+            .from(feed)
             .where(
                 isOpen(isAvailable),
                 categoryEq(category),
@@ -56,6 +58,13 @@ public class CustomFeedRepositoryImpl implements CustomFeedRepository {
             .orderBy(getSortTypeSpecifier(sortType))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
+            .fetch();
+
+        // feedId 기반 전체 데이터 조회
+        return jpaQueryFactory
+            .selectFrom(feed)
+            .leftJoin(feed.store, store).fetchJoin()
+            .where(feed.id.in(feedIds))
             .fetch();
     }
 
@@ -86,12 +95,15 @@ public class CustomFeedRepositoryImpl implements CustomFeedRepository {
     }
 
     // 정렬 순서 설정
-    private OrderSpecifier<?> getSortTypeSpecifier(SortType sortType) {
-        return switch (sortType) {
-            case PRICE_ASC -> new OrderSpecifier<>(Order.ASC, QFeed.feed.price);
-            case RECENT -> new OrderSpecifier<>(Order.DESC, QFeed.feed.id);
-            default -> new OrderSpecifier<>(Order.DESC, QFeed.feed.registeredUser.doubleValue().divide(QFeed.feed.maxUser.doubleValue()));
-        };
+    private OrderSpecifier<?>[] getSortTypeSpecifier(SortType sortType) {
+        if (sortType == PRICE_ASC) { // PRICE_ASC
+            return new OrderSpecifier[] {
+                new OrderSpecifier<>(Order.ASC, QFeed.feed.price),
+                new OrderSpecifier<>(Order.DESC, QFeed.feed.id)
+            };
+        } else { // RECENT
+            return new OrderSpecifier[] { new OrderSpecifier<>(Order.DESC, QFeed.feed.id) };
+        }
     }
 
     // 신청 가능 여부 필터링

--- a/src/main/java/com/ureca/juksoon/domain/feed/service/FeedService.java
+++ b/src/main/java/com/ureca/juksoon/domain/feed/service/FeedService.java
@@ -45,8 +45,9 @@ public class FeedService {
      */
     @Transactional(readOnly = true)
     public GetHomeInfoRes getHomeInfo(Pageable pageable, String keyword, Category category, boolean isAvailable, SortType sortType) {
-        return new GetHomeInfoRes(feedRepository.findAllByFiltering(pageable, isAvailable, sortType, category, keyword).stream()
-            .map(feed -> new GetFeedRes(feed, null))
+        long maxPage = (feedRepository.countAllByFiltering(isAvailable, category, keyword) + pageable.getPageSize() - 1) / pageable.getPageSize();
+
+        return new GetHomeInfoRes(maxPage, feedRepository.findPageByFiltering(pageable, isAvailable, sortType, category, keyword).stream()            .map(feed -> new GetFeedRes(feed, null))
             .toList());
     }
 

--- a/src/main/java/com/ureca/juksoon/domain/feed/service/FeedService.java
+++ b/src/main/java/com/ureca/juksoon/domain/feed/service/FeedService.java
@@ -60,20 +60,28 @@ public class FeedService {
 
         if(user.getRole() == UserRole.ROLE_TESTER) { // 일반 사용자
             // Reservation 기반 조회
-            List<GetFeedRes> feedResList = feedRepository.findAllByUserOrderByFeedIdDesc(pageable, user, lastFeedId).stream()
+            List<GetFeedRes> feedResList = new ArrayList<>(feedRepository.findAllByUserOrderByFeedIdDesc(pageable, user, lastFeedId).stream()
                 .map(f -> new GetFeedRes(f, user.getRole()))
-                .toList();
+                .toList());
 
-            return new GetMypageInfoRes(user.getId(), user.getNickname(), user.getRole(), feedResList);
+            // 다음 페이지 확인 및 반환값 조정
+            boolean hasNextPage = (feedResList.size() > pageable.getPageSize());
+            if(hasNextPage) feedResList.remove(feedResList.size() - 1);
+
+            return new GetMypageInfoRes(user.getId(), user.getNickname(), user.getRole(), hasNextPage, feedResList);
         } else if(user.getRole() == UserRole.ROLE_OWNER) { // 사장님
             Store store = findStoreByUserId(user.getId());
 
             // store 기반 조회
-            List<GetFeedRes> feedResList = feedRepository.findAllByStoreOrderByFeedIdDesc(pageable, store, lastFeedId).stream()
+            List<GetFeedRes> feedResList = new ArrayList<>(feedRepository.findAllByStoreOrderByFeedIdDesc(pageable, store, lastFeedId).stream()
                 .map(feed -> new GetFeedRes(feed, user.getRole()))
-                .toList();
+                .toList());
 
-            return new GetMypageInfoRes(store.getId(), store.getName(), user.getRole(), feedResList);
+            // 다음 페이지 확인 및 반환값 조정
+            boolean hasNextPage = (feedResList.size() > pageable.getPageSize());
+            if(hasNextPage) feedResList.remove(feedResList.size() - 1);
+
+            return new GetMypageInfoRes(store.getId(), store.getName(), user.getRole(), hasNextPage, feedResList);
         }
 
         // 이외의 경우에는 myPage 접근 불가

--- a/src/main/java/com/ureca/juksoon/domain/feed/service/FeedService.java
+++ b/src/main/java/com/ureca/juksoon/domain/feed/service/FeedService.java
@@ -47,8 +47,8 @@ public class FeedService {
     public GetHomeInfoRes getHomeInfo(Pageable pageable, String keyword, Category category, boolean isAvailable, SortType sortType) {
         long maxPage = (feedRepository.countAllByFiltering(isAvailable, category, keyword) + pageable.getPageSize() - 1) / pageable.getPageSize();
 
-        return new GetHomeInfoRes(maxPage, feedRepository.findPageByFiltering(pageable, isAvailable, sortType, category, keyword).stream()            .map(feed -> new GetFeedRes(feed, null))
-            .toList());
+        return new GetHomeInfoRes(maxPage, feedRepository.findPageByFiltering(pageable, isAvailable, sortType, category, keyword).stream()
+            .map(GetFeedRes::new).toList());
     }
 
     /**
@@ -61,8 +61,7 @@ public class FeedService {
         if(user.getRole() == UserRole.ROLE_TESTER) { // 일반 사용자
             // Reservation 기반 조회
             List<GetFeedRes> feedResList = new ArrayList<>(feedRepository.findAllByUserOrderByFeedIdDesc(pageable, user, lastFeedId).stream()
-                .map(f -> new GetFeedRes(f, user.getRole()))
-                .toList());
+                .map(GetFeedRes::new).toList());
 
             // 다음 페이지 확인 및 반환값 조정
             boolean hasNextPage = (feedResList.size() > pageable.getPageSize());
@@ -74,8 +73,7 @@ public class FeedService {
 
             // store 기반 조회
             List<GetFeedRes> feedResList = new ArrayList<>(feedRepository.findAllByStoreOrderByFeedIdDesc(pageable, store, lastFeedId).stream()
-                .map(feed -> new GetFeedRes(feed, user.getRole()))
-                .toList());
+                .map(GetFeedRes::new).toList());
 
             // 다음 페이지 확인 및 반환값 조정
             boolean hasNextPage = (feedResList.size() > pageable.getPageSize());


### PR DESCRIPTION
## ✨ 작업 내용 개요
- docker 파일 추가
- Home 조회 시 default 필터 설정
- Home 조회 시 maxPage 반환
- User/Owner 카드값 동일하게 반환
- Feed Index 추가를 통한 조회 성능 개선

## 🛠️ 작업 사항 상세
- maxPage는 프론트 기준으로 반환합니다. BE로 보낼 때는 사용자가 클릭한 수 - 1 값으로 보내주시면 됩니다!
- Feed에 새로운 index를 추가하였습니다. (price, id)
    - 가격이 동일하다면 최신인 것을 맨 위로 올립니다.
    - 조인 후 필터링이 아닌, 필터링 후 조인으로 실행 순서를 바꿔서 index가 적용되도록 수정하였습니다.
    - 기존 RECENT는 5-60ms -> 3-50ms로, PRICE_ASC는 100-120ms -> 3-50ms로 조회 성능이 개선되었습니다. (Filtering이 최소한인 경우로, keyword는 LIKE 조회를 수행하여 속도 저하가 발생합니다.)

## 🔎 관련 이슈

## ✅ PR Checklist

> PR을 열기 전 점검해보세요!

- [x]  기능이 정확하게 동작합니다.
- [x]  더 나은 코드에 대해서 고민해보았습니다.
- [x]  구현한 기능에 대한 테스트를 진행했습니다.
- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x]  라벨과 리뷰어를 설정했습니다.
- [x]  민감파일(*.yml 등) .gitignore 설정했습니다.

## 📚 참고자료
